### PR TITLE
Add browser-side state legislation comparison

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,11 +3,23 @@ import type {NextConfig} from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: false,
+  turbopack: {},
   typescript: {
     ignoreBuildErrors: true,
   },
   eslint: {
     ignoreDuringBuilds: true,
+  },
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        sharp$: false,
+        'onnxruntime-node$': false,
+      };
+      config.experiments = { ...config.experiments, asyncWebAssembly: true };
+    }
+    return config;
   },
   images: {
     remotePatterns: [

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,17 +10,6 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-  webpack: (config, { isServer }) => {
-    if (!isServer) {
-      config.resolve.alias = {
-        ...config.resolve.alias,
-        sharp$: false,
-        'onnxruntime-node$': false,
-      };
-      config.experiments = { ...config.experiments, asyncWebAssembly: true };
-    }
-    return config;
-  },
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@genkit-ai/googleai": "^1.26.0",
         "@genkit-ai/next": "^1.26.0",
         "@hookform/resolvers": "^4.1.3",
+        "@huggingface/transformers": "^4.2.0",
         "@opentelemetry/exporter-jaeger": "^2.0.1",
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",
@@ -1334,7 +1335,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.0.tgz",
       "integrity": "sha512-Vj3MST245nq+V5UmmfEkB3isIgPouyUr8yGJlFeL9Trg/umG5ogAvrjAYvQ8gV7daKDoQSRnJKWI2JFpQqRsuQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.17",
         "@firebase/logger": "0.4.4",
@@ -1401,7 +1401,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.0.tgz",
       "integrity": "sha512-LjLUrzbUgTa/sCtPoLKT2C7KShvLVHS3crnU1Du02YxnGVLE0CUBGY/NxgfR/Zg84mEbj1q08/dgesojxjn0dA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.13.0",
         "@firebase/component": "0.6.17",
@@ -1417,8 +1416,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.5.26",
@@ -1882,7 +1880,6 @@
       "integrity": "sha512-Z4rK23xBCwgKDqmzGVMef+Vb4xso2j5Q8OG0vVL4m4fA5ZjPMYQazu8OJJC3vtQRC3SQ/Pgx/6TPNVsCd70QRw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2273,7 +2270,6 @@
       "integrity": "sha512-88uZ+jLsp1aVMj7gh3EKYH1aulTAMFAp8sH/v5a9w8q8iqSG27RiWLoxSAFr/XocZ9hGiWH1kEnBw+zl3xAgNA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
         "fast-deep-equal": "^3.1.1",
@@ -2849,6 +2845,34 @@
         "react-hook-form": "^7.0.0"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2915,7 +2939,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -4386,7 +4409,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4765,7 +4787,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4861,7 +4882,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
       "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.25.1"
       },
@@ -6054,7 +6074,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
       "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/semantic-conventions": "1.25.1"
@@ -6097,7 +6116,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
       "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources": "1.25.1",
@@ -6151,7 +6169,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
       "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources": "1.25.1",
@@ -8860,7 +8877,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
       "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.101.2"
       },
@@ -9520,7 +9536,6 @@
       "version": "20.17.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
       "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -9574,7 +9589,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -9585,7 +9599,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -10093,7 +10106,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10136,7 +10148,6 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
       "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -10683,6 +10694,13 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -12000,10 +12018,15 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -12027,8 +12050,7 @@
       "version": "0.0.1495869",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
       "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -12486,6 +12508,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -12546,6 +12574,18 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/escodegen": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
@@ -12572,7 +12612,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12860,18 +12899,6 @@
         }
       }
     },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -13087,7 +13114,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -13444,7 +13470,6 @@
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.8.1.tgz",
       "integrity": "sha512-oetXhPCvJZM4DVL/n/06442emMU+KzM0JLZjszpwlU6mqdFZqBwumBxn6hQkLukJyU5wsjihZHUY8HEAE2micg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/ai": "1.3.0",
         "@firebase/analytics": "0.10.16",
@@ -13552,6 +13577,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.3.3",
@@ -13829,6 +13860,7 @@
       "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
@@ -13843,6 +13875,7 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -13856,6 +13889,7 @@
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -13874,6 +13908,7 @@
       "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
@@ -13890,6 +13925,7 @@
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -13903,7 +13939,8 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gcp-metadata/node_modules/node-fetch": {
       "version": "2.7.0",
@@ -13911,6 +13948,7 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -13931,7 +13969,6 @@
       "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.26.0.tgz",
       "integrity": "sha512-+bfQWefF56mZU8RTH0zHwlXyreA1rMkEXBBb5mNqP1OVuv92F8eJWP80/8M+wvL8OeaxBiejtbGIjcepOJRgpA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@genkit-ai/ai": "1.26.0",
         "@genkit-ai/core": "1.26.0",
@@ -14196,6 +14233,23 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -14396,6 +14450,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -14573,8 +14633,7 @@
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.4.0.tgz",
       "integrity": "sha512-o6UxxfChSUrvrZUbWrAuqL1HO/+exhAUPcZY6nnqLsadZQlnP16d082sg7DnXKZCk1gtfkyfkp6g3qkIZ9miZg==",
-      "license": "https://www.highcharts.com/license",
-      "peer": true
+      "license": "https://www.highcharts.com/license"
     },
     "node_modules/highcharts-react-official": {
       "version": "3.2.2",
@@ -15506,7 +15565,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -15637,6 +15695,12 @@
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -15823,8 +15887,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -16146,7 +16209,6 @@
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.6.2.tgz",
       "integrity": "sha512-SEqYThhUCFf6Lm0TckpgpKnto5u4JsdPYdFJb6g12VtuaFsm3nYdBO+fOmnUYddc8dXihgoGnuXvPPooUcRv5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -16187,6 +16249,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -17393,7 +17467,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.0.7.tgz",
       "integrity": "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.0.7",
         "@swc/helpers": "0.5.15",
@@ -17715,6 +17788,49 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+      "license": "MIT"
     },
     "node_modules/open": {
       "version": "6.4.0",
@@ -18399,6 +18515,12 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -18458,7 +18580,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -19002,7 +19123,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19043,7 +19163,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19055,7 +19174,6 @@
       "version": "7.54.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -19568,6 +19686,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/robust-predicates": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
@@ -19827,6 +19962,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
     "node_modules/send": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
@@ -19865,6 +20006,21 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
@@ -19959,7 +20115,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -20135,7 +20290,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.5.tgz",
       "integrity": "sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -20800,7 +20954,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -21111,7 +21264,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21247,7 +21399,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -21319,7 +21470,6 @@
       "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -21344,6 +21494,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -21454,7 +21616,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21852,7 +22013,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -21986,7 +22146,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22111,7 +22270,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22414,7 +22572,6 @@
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",
@@ -22788,7 +22945,6 @@
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
     "dev": "next dev --turbopack",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "fetch-voting-records": "tsx src/scripts/fetchVotingRecords.ts",
+    "build-embeddings": "tsx src/scripts/build-legislation-embeddings.ts",
     "postinstall": "patch-package"
   },
   "dependencies": {
@@ -21,6 +22,7 @@
     "@genkit-ai/googleai": "^1.26.0",
     "@genkit-ai/next": "^1.26.0",
     "@hookform/resolvers": "^4.1.3",
+    "@huggingface/transformers": "^4.2.0",
     "@opentelemetry/exporter-jaeger": "^2.0.1",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",

--- a/src/app/(main)/summaries/page.tsx
+++ b/src/app/(main)/summaries/page.tsx
@@ -1,5 +1,5 @@
 import { PageHeader } from '@/components/layout/PageHeader';
-import { EmptyState } from '@/components/layout/EmptyState';
+import { StateLegislationComparison } from '@/components/features/StateLegislationComparison';
 import { pageMetadata } from '@/lib/metadata';
 
 export const metadata = pageMetadata.summaries;
@@ -7,11 +7,11 @@ export const metadata = pageMetadata.summaries;
 export default function SummariesPage() {
   return (
     <div className="animate-content-in space-y-6">
-      <PageHeader title="AI Summaries" subtitle="AI-powered legislative summarization tools." />
-      <EmptyState
-        title="Summarization tool is under construction"
-        description="This feature will return soon. Existing bill detail summaries remain available on individual legislation pages."
+      <PageHeader
+        title="Compare States"
+        subtitle="Search a policy issue and compare how states approach it — powered by browser-side AI, no API keys."
       />
+      <StateLegislationComparison />
     </div>
   );
 }

--- a/src/app/api/legislation/[id]/detailed-summary/route.ts
+++ b/src/app/api/legislation/[id]/detailed-summary/route.ts
@@ -3,7 +3,7 @@ import { getLegislationById } from '@/services/legislationService';
 import { checkRateLimit } from '@/services/rateLimitService';
 import { getCollection } from '@/lib/mongodb';
 import { ai } from '@/ai/genkit';
-import pdf from 'pdf-parse';
+import { parsePdfBuffer } from '@/lib/pdfParse';
 import * as cheerio from 'cheerio';
 import type { Legislation } from '@/types/legislation';
 
@@ -103,7 +103,7 @@ async function generateDetailedSummaryFromBill(legislation: Legislation): Promis
       }
       const buffer = await pdfRes.arrayBuffer();
       
-      const data = await pdf(Buffer.from(buffer));
+      const data = await parsePdfBuffer(Buffer.from(buffer));
     //   console.log('[DEBUG] PDF text length:', data.text?.length || 0);
 
       if (data.text && data.text.trim().length > 500) {

--- a/src/app/api/legislation/compare/route.ts
+++ b/src/app/api/legislation/compare/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getComparisonCandidates } from '@/services/stateLegislationComparisonService';
+
+const CACHE_TTL = 5 * 60 * 1000;
+const cache = new Map<string, { data: unknown; timestamp: number }>();
+
+const RATE_LIMIT_WINDOW = 60 * 1000;
+const RATE_LIMIT_MAX = 10;
+const rateLimits = new Map<string, { count: number; resetAt: number }>();
+
+function getClientId(request: NextRequest): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'anonymous'
+  );
+}
+
+function checkRateLimit(clientId: string): boolean {
+  const now = Date.now();
+  const entry = rateLimits.get(clientId);
+
+  if (!entry || now >= entry.resetAt) {
+    rateLimits.set(clientId, { count: 1, resetAt: now + RATE_LIMIT_WINDOW });
+    return true;
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX) return false;
+  entry.count += 1;
+  return true;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const clientId = getClientId(request);
+    if (!checkRateLimit(clientId)) {
+      return NextResponse.json(
+        { message: 'Rate limit exceeded. Try again in a minute.' },
+        { status: 429 },
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const q = searchParams.get('q') || '';
+    const enactedOnly = searchParams.get('enactedOnly') === 'true';
+    const showCongress = searchParams.get('showCongress') === 'true';
+
+    if (!q.trim()) {
+      return NextResponse.json(
+        { message: 'Query parameter "q" is required.' },
+        { status: 400 },
+      );
+    }
+
+    const cacheKey = `${q}|${enactedOnly}|${showCongress}`;
+    const cached = cache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+      return NextResponse.json(cached.data, { status: 200 });
+    }
+
+    const result = await getComparisonCandidates(q, { enactedOnly, showCongress });
+    cache.set(cacheKey, { data: result, timestamp: Date.now() });
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    console.error('Error in legislation compare API:', error);
+    return NextResponse.json(
+      { message: 'Error fetching comparison candidates', error: (error as Error).message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/features/RepresentativesFinder.tsx
+++ b/src/components/features/RepresentativesFinder.tsx
@@ -13,6 +13,7 @@ import {MessageGenerator} from "./MessageGenerator";
 import {RepresentativesResults} from "./RepresentativesResults";
 import {ApiResponse, Representative} from "@/types/representative";
 import {AddressSuggestion, STATE_COORDINATES, STATE_MAP} from "@/types/geo";
+import { setStoredUserState, resolveStateName } from "@/lib/userStateStorage";
 import {getStateAbbrFromString, getStateAbbreviation} from "@/lib/locationUtils";
 
 // Dynamically import the map component to avoid SSR issues
@@ -243,6 +244,8 @@ export function RepresentativesFinder() {
 
     const handleAddressSelect = (suggestion: AddressSuggestion) => {
         setUserLocation(suggestion);
+        const stateName = resolveStateName(suggestion.address?.state);
+        if (stateName) setStoredUserState(stateName);
         void fetchRepresentatives(suggestion);
     };
 
@@ -263,6 +266,8 @@ export function RepresentativesFinder() {
         };
 
         setUserLocation(manualLocation);
+        const stateName = resolveStateName(state || manualLocation.address?.state);
+        if (stateName) setStoredUserState(stateName);
         setShowMap(false); // Don't show map for manual searches without coordinates
         void fetchRepresentatives(manualLocation);
     };
@@ -351,6 +356,8 @@ export function RepresentativesFinder() {
                 };
 
                 setUserLocation(stateLocation);
+                const resolved = resolveStateName(stateName || stateAbbr);
+                if (resolved) setStoredUserState(resolved);
                 setShowMap(false); // Don't show map for state-only searches
                 void fetchRepresentatives(stateLocation);
             }

--- a/src/components/features/StateLegislationComparison.tsx
+++ b/src/components/features/StateLegislationComparison.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  groupByState,
+  rerankCandidates,
+  type CompareCandidate,
+  type StateComparisonRow,
+} from "@/lib/comparisonScoring";
+import { getStoredUserState, setStoredUserState } from "@/lib/userStateStorage";
+import { STATE_NAMES } from "@/types/geo";
+import { useSemanticSearch } from "@/hooks/useSemanticSearch";
+import { useComparisonSynthesis } from "@/hooks/useComparisonSynthesis";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Loader2, Search, Sparkles, ChevronDown, ChevronUp, ExternalLink } from "lucide-react";
+import { AnimatedSection } from "@/components/ui/AnimatedSection";
+
+const STATE_OPTIONS = Object.entries(STATE_NAMES)
+  .filter(([abbr]) => abbr !== "US")
+  .sort(([, a], [, b]) => a.localeCompare(b));
+
+interface CompareApiResponse {
+  query: string;
+  detectedTopics: { broad: string[]; narrow: string[] };
+  candidates: CompareCandidate[];
+}
+
+export function StateLegislationComparison() {
+  const [query, setQuery] = useState("");
+  const [userState, setUserState] = useState("");
+  const [enactedOnly, setEnactedOnly] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [detectedTopics, setDetectedTopics] = useState<string[]>([]);
+  const [stateResults, setStateResults] = useState<StateComparisonRow[]>([]);
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+
+  const { embedQuery, modelState } = useSemanticSearch();
+  const { synthesis, synthState, generateComparison, resetSynthesis } = useComparisonSynthesis();
+
+  useEffect(() => {
+    const stored = getStoredUserState();
+    if (stored) setUserState(stored);
+  }, []);
+
+  const handleStateChange = (value: string) => {
+    setUserState(value);
+    setStoredUserState(value);
+  };
+
+  const toggleRow = (jurisdiction: string) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(jurisdiction)) next.delete(jurisdiction);
+      else next.add(jurisdiction);
+      return next;
+    });
+  };
+
+  const handleSearch = useCallback(async () => {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+
+    setIsSearching(true);
+    setError(null);
+    resetSynthesis();
+    setStateResults([]);
+
+    try {
+      const params = new URLSearchParams({ q: trimmed });
+      if (enactedOnly) params.set("enactedOnly", "true");
+
+      const res = await fetch(`/api/legislation/compare?${params.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message || "Search failed");
+      }
+
+      const data: CompareApiResponse = await res.json();
+      const topics = [...data.detectedTopics.broad, ...data.detectedTopics.narrow];
+      setDetectedTopics(topics);
+
+      const queryVec = await embedQuery(trimmed);
+      const ranked = rerankCandidates(trimmed, queryVec, data.candidates, topics);
+      const grouped = groupByState(ranked, userState || undefined);
+      setStateResults(grouped);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsSearching(false);
+    }
+  }, [query, enactedOnly, userState, embedQuery, resetSynthesis]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") handleSearch();
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card className="shadow-lg">
+        <CardHeader>
+          <CardTitle className="font-headline text-2xl">Compare State Legislation</CardTitle>
+          <CardDescription>
+            Search a policy issue and see how each state&apos;s most relevant bill compares. Semantic
+            search runs in your browser — no API keys required.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder='e.g. "minimum wage", "gun control", "paid family leave"'
+                className="pl-9"
+              />
+            </div>
+            <Button onClick={handleSearch} disabled={isSearching || !query.trim()}>
+              {isSearching ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Searching…
+                </>
+              ) : (
+                "Compare States"
+              )}
+            </Button>
+          </div>
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+            <div className="flex-1 space-y-2">
+              <Label htmlFor="user-state">Your state (optional)</Label>
+              <Select value={userState} onValueChange={handleStateChange}>
+                <SelectTrigger id="user-state">
+                  <SelectValue placeholder="Select your state" />
+                </SelectTrigger>
+                <SelectContent>
+                  {STATE_OPTIONS.map(([abbr, name]) => (
+                    <SelectItem key={abbr} value={name}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2 pb-2">
+              <Checkbox
+                id="enacted-only"
+                checked={enactedOnly}
+                onCheckedChange={(v) => setEnactedOnly(v === true)}
+              />
+              <Label htmlFor="enacted-only" className="cursor-pointer">
+                Enacted bills only
+              </Label>
+            </div>
+          </div>
+
+          {modelState === "loading" && (
+            <p className="text-sm text-muted-foreground">
+              Loading semantic search model (one-time ~23 MB download)…
+            </p>
+          )}
+          {modelState === "error" && (
+            <p className="text-sm text-amber-600">
+              Semantic model unavailable — using keyword matching instead.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {error && (
+        <Card className="border-destructive/50">
+          <CardContent className="p-4 text-sm text-destructive">{error}</CardContent>
+        </Card>
+      )}
+
+      {detectedTopics.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {detectedTopics.map((topic) => (
+            <Badge key={topic} variant="secondary">
+              {topic}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {stateResults.length > 0 && (
+        <AnimatedSection>
+          <Card className="shadow-lg">
+            <CardHeader className="flex flex-row items-center justify-between gap-4">
+              <div>
+                <CardTitle className="text-lg">
+                  Results across {stateResults.length} jurisdictions
+                </CardTitle>
+                <CardDescription>Top matching bill per state, ranked by relevance</CardDescription>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={synthState === "loading"}
+                onClick={() => generateComparison(query, stateResults, userState)}
+              >
+                {synthState === "loading" ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Generating…
+                  </>
+                ) : (
+                  <>
+                    <Sparkles className="mr-2 h-4 w-4" />
+                    Generate Comparison
+                  </>
+                )}
+              </Button>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {(synthesis || synthState === "loading") && (
+                <div className="rounded-lg border bg-muted/40 p-4 space-y-2">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Browser-generated comparison
+                  </p>
+                  {synthState === "loading" ? (
+                    <p className="text-sm text-muted-foreground">
+                      Generating comparison in your browser (~30 MB model, one-time download)…
+                    </p>
+                  ) : (
+                    <p className="text-sm leading-relaxed">{synthesis}</p>
+                  )}
+                  {synthesis && (
+                    <p className="text-xs text-muted-foreground">
+                      Generated in your browser from the bills above. Not human-curated — verify
+                      against the quoted text.
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {stateResults.map((row) => {
+                const bill = row.topBill;
+                const expanded = expandedRows.has(row.jurisdictionName);
+                return (
+                  <div
+                    key={row.jurisdictionName}
+                    className={`rounded-lg border p-4 ${
+                      row.isUserState ? "border-primary bg-primary/5" : ""
+                    }`}
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <h3 className="font-semibold">{row.jurisdictionName}</h3>
+                          {row.isUserState && <Badge>Your state</Badge>}
+                          {bill?.enactedAt && <Badge variant="outline">Enacted</Badge>}
+                        </div>
+                        {bill ? (
+                          <Link
+                            href={`/legislation/${bill.id}`}
+                            className="text-sm text-primary hover:underline inline-flex items-center gap-1"
+                          >
+                            {bill.identifier}: {bill.title}
+                            <ExternalLink className="h-3 w-3" />
+                          </Link>
+                        ) : (
+                          <p className="text-sm text-muted-foreground">No matching bill found</p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="secondary">
+                          {(row.score * 100).toFixed(0)}% match
+                        </Badge>
+                        {bill && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => toggleRow(row.jurisdictionName)}
+                          >
+                            {expanded ? (
+                              <ChevronUp className="h-4 w-4" />
+                            ) : (
+                              <ChevronDown className="h-4 w-4" />
+                            )}
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+
+                    {bill?.geminiSummary && !expanded && (
+                      <p className="mt-2 text-sm text-muted-foreground line-clamp-2">
+                        {bill.geminiSummary}
+                      </p>
+                    )}
+
+                    {expanded && bill && (
+                      <div className="mt-3 space-y-2 text-sm text-muted-foreground border-t pt-3">
+                        {bill.geminiSummary && <p>{bill.geminiSummary}</p>}
+                        {bill.longGeminiSummary && bill.longGeminiSummary !== bill.geminiSummary && (
+                          <p className="italic">{bill.longGeminiSummary}</p>
+                        )}
+                        {bill.statusText && (
+                          <p>
+                            <span className="font-medium text-foreground">Status:</span>{" "}
+                            {bill.statusText}
+                          </p>
+                        )}
+                        {bill.chamber && (
+                          <p>
+                            <span className="font-medium text-foreground">Chamber:</span>{" "}
+                            {bill.chamber}
+                          </p>
+                        )}
+                        {bill.subjects && bill.subjects.length > 0 && (
+                          <div className="flex flex-wrap gap-1">
+                            {bill.subjects.slice(0, 5).map((s) => (
+                              <Badge key={s} variant="outline" className="text-xs">
+                                {s}
+                              </Badge>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+        </AnimatedSection>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -8,7 +8,7 @@ const NAV_LINKS = [
   { href: "/executive-orders", label: "Executive Orders" },
   { href: "/tracker", label: "Track Policies" },
   { href: "/representatives", label: "Representatives" },
-  { href: "/summaries", label: "AI Summaries" },
+  { href: "/summaries", label: "Compare States" },
   { href: "/civic", label: "Civic Tools" },
 ];
 

--- a/src/components/layout/AppNav.tsx
+++ b/src/components/layout/AppNav.tsx
@@ -25,6 +25,7 @@ const NAV_GROUPS: Array<
     items: [
       { href: "/dashboard", label: "Dashboard" },
       { href: "/legislation", label: "Legislation" },
+      { href: "/summaries", label: "Compare States" },
       { href: "/executive-orders", label: "Executive Orders" },
       { href: "/tracker", label: "Tracker" },
     ],

--- a/src/hooks/useComparisonSynthesis.ts
+++ b/src/hooks/useComparisonSynthesis.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { StateComparisonRow } from '@/lib/comparisonScoring';
+
+export type SynthState = 'idle' | 'loading' | 'ready' | 'error';
+
+type Text2TextPipeline = Awaited<
+  ReturnType<typeof import('@huggingface/transformers')['pipeline']>
+>;
+
+let generatorPromise: Promise<Text2TextPipeline> | null = null;
+
+async function getGenerator(): Promise<Text2TextPipeline> {
+  if (!generatorPromise) {
+    generatorPromise = (async () => {
+      const { pipeline } = await import('@huggingface/transformers');
+      return pipeline('text2text-generation', 'Xenova/LaMini-Flan-T5-77M');
+    })();
+  }
+  return generatorPromise;
+}
+
+export function useComparisonSynthesis() {
+  const [synthesis, setSynthesis] = useState<string | null>(null);
+  const [synthState, setSynthState] = useState<SynthState>('idle');
+
+  const generateComparison = useCallback(
+    async (query: string, stateResults: StateComparisonRow[], userState?: string) => {
+      const withBills = stateResults.filter((r) => r.topBill);
+      if (withBills.length < 2) {
+        setSynthesis('Not enough matching bills across states to generate a comparison.');
+        setSynthState('ready');
+        return;
+      }
+
+      try {
+        setSynthState('loading');
+        setSynthesis(null);
+
+        const generator = await getGenerator();
+        const context = withBills
+          .slice(0, 5)
+          .map(
+            (row) =>
+              `[${row.jurisdictionName}, ${row.topBill?.identifier || 'bill'}]: ${
+                row.topBill?.geminiSummary || row.topBill?.title || ''
+              }`,
+          )
+          .join('\n\n');
+
+        const prompt = `Based only on these state bills about "${query}", write a brief comparison paragraph. Mention how ${
+          userState || 'different states'
+        } compare. Be factual and cite bill identifiers.
+
+Bills:
+${context}
+
+Comparison:`;
+
+        const out = await generator(prompt, { max_new_tokens: 150, temperature: 0.2 });
+        const text = (out as Array<{ generated_text?: string }>)?.[0]?.generated_text?.trim();
+
+        setSynthesis(text || 'Could not generate a comparison summary.');
+        setSynthState('ready');
+      } catch (error) {
+        console.error('Synthesis failed:', error);
+        setSynthesis(null);
+        setSynthState('error');
+      }
+    },
+    [],
+  );
+
+  const resetSynthesis = useCallback(() => {
+    setSynthesis(null);
+    setSynthState('idle');
+  }, []);
+
+  return { synthesis, synthState, generateComparison, resetSynthesis };
+}

--- a/src/hooks/useSemanticSearch.ts
+++ b/src/hooks/useSemanticSearch.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+export type ModelState = 'idle' | 'loading' | 'ready' | 'error';
+
+type FeaturePipeline = Awaited<
+  ReturnType<typeof import('@huggingface/transformers')['pipeline']>
+>;
+
+let extractorPromise: Promise<FeaturePipeline> | null = null;
+
+async function getExtractor(): Promise<FeaturePipeline> {
+  if (!extractorPromise) {
+    extractorPromise = (async () => {
+      const { pipeline } = await import('@huggingface/transformers');
+      return pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
+    })();
+  }
+  return extractorPromise;
+}
+
+export function useSemanticSearch() {
+  const [modelState, setModelState] = useState<ModelState>('idle');
+
+  const embedQuery = useCallback(async (text: string): Promise<Float32Array | null> => {
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+
+    try {
+      setModelState('loading');
+      const extractor = await getExtractor();
+      const out = await extractor(trimmed, { pooling: 'mean', normalize: true });
+      setModelState('ready');
+      return out.data as Float32Array;
+    } catch (error) {
+      console.error('Failed to embed query:', error);
+      setModelState('error');
+      return null;
+    }
+  }, []);
+
+  const warmModel = useCallback(async () => {
+    try {
+      setModelState('loading');
+      await getExtractor();
+      setModelState('ready');
+    } catch {
+      setModelState('error');
+    }
+  }, []);
+
+  return { embedQuery, warmModel, modelState };
+}

--- a/src/lib/comparisonScoring.ts
+++ b/src/lib/comparisonScoring.ts
@@ -1,0 +1,116 @@
+import { STATE_MAP } from '@/types/geo';
+
+export interface CompareCandidate {
+  id: string;
+  identifier?: string;
+  title?: string;
+  jurisdictionName?: string;
+  embedding?: number[];
+  geminiSummary?: string | null;
+  longGeminiSummary?: string | null;
+  enactedAt?: string | null;
+  latestActionAt?: string | null;
+  statusText?: string | null;
+  chamber?: string | null;
+  subjects?: string[];
+  score?: number;
+}
+
+export interface StateComparisonRow {
+  jurisdictionName: string;
+  stateAbbr: string;
+  topBill: CompareCandidate | null;
+  isUserState: boolean;
+  score: number;
+}
+
+export function dotProduct(a: Float32Array | number[], b: number[]): number {
+  let sum = 0;
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) sum += a[i] * b[i];
+  return sum;
+}
+
+export function keywordScore(query: string, bill: CompareCandidate, topics: string[]): number {
+  const q = query.toLowerCase();
+  const terms = q.split(/\s+/).filter((t) => t.length > 2);
+  let score = 0;
+
+  const fields = [
+    bill.title,
+    bill.geminiSummary,
+    bill.identifier,
+    ...(bill.subjects || []),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  for (const term of terms) {
+    if (fields.includes(term)) score += 10;
+  }
+
+  for (const topic of topics) {
+    if (fields.includes(topic.toLowerCase())) score += 15;
+  }
+
+  if (bill.title && terms.some((t) => bill.title!.toLowerCase().includes(t))) {
+    score += 20;
+  }
+
+  return score;
+}
+
+export function rerankCandidates(
+  query: string,
+  queryVec: Float32Array | null,
+  candidates: CompareCandidate[],
+  topics: string[],
+): CompareCandidate[] {
+  return candidates
+    .map((candidate) => {
+      let score = 0;
+      if (queryVec && candidate.embedding?.length) {
+        score = dotProduct(queryVec, candidate.embedding);
+      } else {
+        score = keywordScore(query, candidate, topics) / 100;
+      }
+      return { ...candidate, score };
+    })
+    .sort((a, b) => (b.score || 0) - (a.score || 0));
+}
+
+export function groupByState(
+  ranked: CompareCandidate[],
+  userState?: string,
+): StateComparisonRow[] {
+  const seen = new Set<string>();
+  const rows: StateComparisonRow[] = [];
+  const normalizedUserState = userState?.toLowerCase();
+
+  for (const bill of ranked) {
+    const jurisdiction = bill.jurisdictionName || 'Unknown';
+    if (seen.has(jurisdiction)) continue;
+    seen.add(jurisdiction);
+
+    const stateAbbr = STATE_MAP[jurisdiction] || jurisdiction.slice(0, 2).toUpperCase();
+    rows.push({
+      jurisdictionName: jurisdiction,
+      stateAbbr,
+      topBill: bill,
+      isUserState: normalizedUserState
+        ? jurisdiction.toLowerCase() === normalizedUserState ||
+          stateAbbr.toLowerCase() === normalizedUserState
+        : false,
+      score: bill.score || 0,
+    });
+  }
+
+  rows.sort((a, b) => {
+    if (a.isUserState && !b.isUserState) return -1;
+    if (!a.isUserState && b.isUserState) return 1;
+    return b.score - a.score;
+  });
+
+  return rows;
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,29 +1,52 @@
 import nodemailer from 'nodemailer';
-import dotenv from 'dotenv';
+import type Transporter from 'nodemailer/lib/mailer';
 
-dotenv.config({ path: require('path').resolve(__dirname, '../../.env') });
+let transporter: Transporter | null = null;
 
-const smtpUser = process.env.SMTP_USER;
-const smtpPass = process.env.SMTP_PASS;
-const smtpFrom = process.env.SMTP_FROM;
-const smtpHost = process.env.SMTP_HOST;
-const smtpPort = Number(process.env.SMTP_PORT) || 587;
+function getTransporter(): Transporter {
+  if (transporter) return transporter;
 
-if (!smtpUser || !smtpPass || !smtpFrom || !smtpHost || !smtpPort) {
-    throw new Error('Missing SMTP_USER, SMTP_PASS, SMTP_FROM, SMTP_HOST, or SMTP_PORT in environment variables');
+  const smtpUser = process.env.SMTP_USER;
+  const smtpPass = process.env.SMTP_PASS;
+  const smtpFrom = process.env.SMTP_FROM;
+  const smtpHost = process.env.SMTP_HOST;
+  const smtpPort = Number(process.env.SMTP_PORT) || 587;
+
+  if (!smtpUser || !smtpPass || !smtpFrom || !smtpHost || !smtpPort) {
+    throw new Error(
+      'Missing SMTP_USER, SMTP_PASS, SMTP_FROM, SMTP_HOST, or SMTP_PORT in environment variables',
+    );
+  }
+
+  transporter = nodemailer.createTransport({
+    host: smtpHost,
+    port: smtpPort,
+    secure: smtpPort === 465,
+    auth: {
+      user: smtpUser,
+      pass: smtpPass,
+    },
+  });
+
+  return transporter;
 }
 
-const transporter = nodemailer.createTransport({
-  host: smtpHost,
-  port: smtpPort,
-  secure: smtpPort === 465, // true for 465, false for 587
-  auth: {
-    user: smtpUser,
-    pass: smtpPass,
-  },
-});
+export async function sendEmail({
+  to,
+  subject,
+  html,
+  text,
+}: {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}) {
+  const smtpFrom = process.env.SMTP_FROM;
+  if (!smtpFrom) {
+    throw new Error('Missing SMTP_FROM in environment variables');
+  }
 
-export async function sendEmail({ to, subject, html, text }: { to: string; subject: string; html: string; text?: string }) {
   const mailOptions = {
     from: smtpFrom,
     to,
@@ -31,5 +54,6 @@ export async function sendEmail({ to, subject, html, text }: { to: string; subje
     html,
     text,
   };
-  return transporter.sendMail(mailOptions);
+
+  return getTransporter().sendMail(mailOptions);
 }

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -116,9 +116,9 @@ export const pageMetadata = {
   }),
 
   summaries: generateMetadata({
-    title: 'AI Summaries - Simplified Policy Analysis',
-    description: 'AI-powered summaries of complex legislation and policy documents, making government information accessible and understandable.',
-    keywords: ['AI summaries', 'policy analysis', 'legislation summaries', 'government documents'],
+    title: 'Compare States - Cross-State Legislation Search',
+    description: 'Search a policy issue and compare how states approach it with browser-side semantic search. No API keys required.',
+    keywords: ['state comparison', 'policy comparison', 'legislation search', 'semantic search', 'state bills'],
     url: '/summaries',
   }),
 

--- a/src/lib/pdf-parse-core.d.ts
+++ b/src/lib/pdf-parse-core.d.ts
@@ -1,0 +1,6 @@
+declare module 'pdf-parse/lib/pdf-parse.js' {
+  import type { Buffer } from 'buffer';
+
+  function pdfParse(data: Buffer): Promise<{ text: string; numpages?: number; info?: unknown }>;
+  export default pdfParse;
+}

--- a/src/lib/pdfParse.ts
+++ b/src/lib/pdfParse.ts
@@ -1,0 +1,17 @@
+import type { Buffer } from 'buffer';
+
+type PdfParseFn = (data: Buffer) => Promise<{ text: string }>;
+
+let pdfParseFn: PdfParseFn | null = null;
+
+/**
+ * Lazy-load pdf-parse from its core module to avoid the package entrypoint's
+ * debug harness that reads ./test/data/05-versions-space.pdf at import time.
+ */
+export async function parsePdfBuffer(data: Buffer): Promise<{ text: string }> {
+  if (!pdfParseFn) {
+    const mod = await import('pdf-parse/lib/pdf-parse.js');
+    pdfParseFn = (mod.default ?? mod) as PdfParseFn;
+  }
+  return pdfParseFn(data);
+}

--- a/src/lib/userStateStorage.ts
+++ b/src/lib/userStateStorage.ts
@@ -1,0 +1,29 @@
+import { STATE_MAP, STATE_NAMES } from '@/types/geo';
+
+export const USER_STATE_STORAGE_KEY = 'statepulse-user-state';
+
+export function resolveStateName(state?: string | null): string | null {
+  if (!state) return null;
+  if (STATE_MAP[state]) return state;
+  const fromAbbr = STATE_NAMES[state.toUpperCase()];
+  if (fromAbbr) return fromAbbr;
+  return state;
+}
+
+export function getStoredUserState(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return sessionStorage.getItem(USER_STATE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredUserState(state: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    sessionStorage.setItem(USER_STATE_STORAGE_KEY, state);
+  } catch {
+    // ignore storage errors
+  }
+}

--- a/src/scripts/build-legislation-embeddings.ts
+++ b/src/scripts/build-legislation-embeddings.ts
@@ -1,0 +1,111 @@
+import { createHash } from 'crypto';
+import { MongoClient } from 'mongodb';
+import dotenv from 'dotenv';
+import type { Legislation } from '@/types/legislation';
+
+dotenv.config({ path: require('path').resolve(__dirname, '../../.env') });
+
+const MONGO_URI = process.env.MONGODB_URI || process.env.MONGO_URI || 'mongodb://localhost:27017';
+const DB_NAME = process.env.MONGODB_DB_NAME || 'statepulse-data';
+const BATCH_SIZE = 50;
+const EMBEDDING_MODEL = 'Xenova/all-MiniLM-L6-v2';
+
+function buildEmbeddingText(bill: Legislation): string {
+  return [bill.title, bill.geminiSummary, bill.subjects?.join(' ')]
+    .filter(Boolean)
+    .join(' ')
+    .slice(0, 512);
+}
+
+function hashText(text: string): string {
+  return createHash('md5').update(text).digest('hex');
+}
+
+async function main() {
+  const limitArg = process.argv.find((a) => a.startsWith('--limit='));
+  const limit = limitArg ? parseInt(limitArg.split('=')[1], 10) : undefined;
+  const force = process.argv.includes('--force');
+
+  console.log(`Connecting to MongoDB: ${MONGO_URI}`);
+  const client = new MongoClient(MONGO_URI);
+
+  try {
+    await client.connect();
+    const collection = client.db(DB_NAME).collection<Legislation>('legislation');
+
+    const { pipeline } = await import('@huggingface/transformers');
+    const embed = await pipeline('feature-extraction', EMBEDDING_MODEL);
+    console.log(`Loaded embedding model: ${EMBEDDING_MODEL}`);
+
+    const query = force
+      ? {}
+      : { $or: [{ embedding: { $exists: false } }, { embedding: null }, { embedding: [] }] };
+
+    const total = await collection.countDocuments(query);
+    const processLimit = limit ?? total;
+    console.log(`Bills to process: ${processLimit} of ${total}`);
+
+    let cursor = collection.find(query).sort({ latestActionAt: -1 });
+    if (limit) {
+      cursor = cursor.limit(limit);
+    }
+    let processed = 0;
+    let skipped = 0;
+
+    while (await cursor.hasNext()) {
+      const batch: Legislation[] = [];
+      for (let i = 0; i < BATCH_SIZE && (await cursor.hasNext()); i++) {
+        const doc = await cursor.next();
+        if (doc) batch.push(doc as Legislation);
+      }
+
+      for (const bill of batch) {
+        const text = buildEmbeddingText(bill);
+        if (!text.trim()) {
+          skipped += 1;
+          continue;
+        }
+
+        const textHash = hashText(text);
+        if (!force && bill.embeddingTextHash === textHash && bill.embedding?.length) {
+          skipped += 1;
+          continue;
+        }
+
+        const out = await embed(text, { pooling: 'mean', normalize: true });
+        const vector = Array.from(out.data as Float32Array).map(
+          (v) => Math.round(v * 1e5) / 1e5,
+        );
+
+        await collection.updateOne(
+          { id: bill.id },
+          {
+            $set: {
+              embedding: vector,
+              embeddingModel: EMBEDDING_MODEL,
+              embeddingTextHash: textHash,
+            },
+          },
+        );
+
+        processed += 1;
+        if (processed % 25 === 0) {
+          console.log(`Embedded ${processed} bills (${skipped} skipped)`);
+        }
+      }
+    }
+
+    console.log(`Done. Embedded ${processed} bills, skipped ${skipped}.`);
+  } finally {
+    await client.close();
+  }
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/src/scripts/createLegislationIndexes.ts
+++ b/src/scripts/createLegislationIndexes.ts
@@ -37,6 +37,12 @@ async function createLegislationIndexes() {
     await legislationCollection.createIndex({ jurisdictionName: 1, updatedAt: 1 });
     console.log('Created compound index on jurisdictionName + updatedAt');
 
+    await legislationCollection.createIndex({ embedding: 1, jurisdictionName: 1, latestActionAt: -1 });
+    console.log('Created compound index on embedding + jurisdictionName + latestActionAt');
+
+    await legislationCollection.createIndex({ 'topicClassification.broadTopics': 1, embedding: 1 });
+    console.log('Created compound index on topicClassification.broadTopics + embedding');
+
     console.log('All indexes created successfully');
 
     // List all indexes to verify

--- a/src/services/aiSummaryUtil.ts
+++ b/src/services/aiSummaryUtil.ts
@@ -1,6 +1,6 @@
 import {ai} from '@/ai/genkit';
 import fetch from 'node-fetch';
-import pdf from 'pdf-parse';
+import { parsePdfBuffer } from '@/lib/pdfParse';
 import * as cheerio from 'cheerio';
 import {Legislation} from '@/types/legislation';
 
@@ -353,7 +353,7 @@ export async function fetchPdfFromOpenStatesUrl(legUrl: string): Promise<{ text:
     }
     const buffer = await pdfRes.arrayBuffer();
     debug.push('PDF fetched, parsing...');
-    const data = await pdf(Buffer.from(buffer));
+    const data = await parsePdfBuffer(Buffer.from(buffer));
     debug.push('PDF parsed successfully.');
     return { text: data.text, debug };
   } catch (err) {
@@ -439,7 +439,7 @@ export async function summarizeLegislationOptimized(bill: Legislation): Promise<
         return null;
       }
       const buffer = await pdfRes.arrayBuffer();
-      const data = await pdf(Buffer.from(buffer));
+      const data = await parsePdfBuffer(Buffer.from(buffer));
       console.log('[DEBUG] PDF text length:', data.text?.length || 0);
 
       if (data.text && data.text.trim().length > 100) {
@@ -649,7 +649,7 @@ export async function summarizeLegislationOptimized(bill: Legislation): Promise<
 
             if (version.url.endsWith('.pdf')) {
               const buffer = await res.arrayBuffer();
-              const pdfText = await pdf(Buffer.from(buffer));
+              const pdfText = await parsePdfBuffer(Buffer.from(buffer));
               billText = pdfText.text;
               sourceType = 'pdf-extracted';
             } else {
@@ -680,7 +680,7 @@ export async function summarizeLegislationOptimized(bill: Legislation): Promise<
 
                 if (linkUrl.endsWith('.pdf')) {
                   const buffer = await res.arrayBuffer();
-                  const pdfText = await pdf(Buffer.from(buffer));
+                  const pdfText = await parsePdfBuffer(Buffer.from(buffer));
                   billText = pdfText.text;
                   sourceType = 'pdf-extracted';
                 } else {

--- a/src/services/federalRegisterService.ts
+++ b/src/services/federalRegisterService.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import { FederalRegisterDocument, ExecutiveOrder } from '@/types/executiveOrder';
 import { upsertExecutiveOrder } from '@/services/executiveOrderService';
-import pdf from 'pdf-parse';
+import { parsePdfBuffer } from '@/lib/pdfParse';
 
 export class FederalRegisterClient {
   private baseUrl = 'https://www.federalregister.gov/api/v1';
@@ -58,7 +58,7 @@ export class FederalRegisterClient {
       }
 
       const buffer = await response.arrayBuffer();
-      const data = await pdf(Buffer.from(buffer));
+      const data = await parsePdfBuffer(Buffer.from(buffer));
       return data.text;
     } catch (error) {
       console.error(`Error extracting PDF text from ${pdfUrl}:`, error);

--- a/src/services/governorScraperService.ts
+++ b/src/services/governorScraperService.ts
@@ -1,6 +1,6 @@
 import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
-import pdf from 'pdf-parse';
+import { parsePdfBuffer } from '@/lib/pdfParse';
 import { GovernorScrapedOrder, ExecutiveOrder } from '@/types/executiveOrder';
 import { upsertExecutiveOrder } from '@/services/executiveOrderService';
 import { getCurrentGovernorName } from './governorInfoService';
@@ -531,7 +531,7 @@ async function extractPdfText(pdfUrl: string): Promise<string | null> {
     if (!response.ok) return null;
 
     const buffer = await response.arrayBuffer();
-    const data = await pdf(Buffer.from(buffer));
+    const data = await parsePdfBuffer(Buffer.from(buffer));
     return data.text;
   } catch (error) {
     console.error(`PDF extraction failed for ${pdfUrl}:`, error);

--- a/src/services/stateLegislationComparisonService.ts
+++ b/src/services/stateLegislationComparisonService.ts
@@ -1,0 +1,161 @@
+import { getCollection } from '@/lib/mongodb';
+import { classifyLegislationTopics } from '@/services/classifyLegislationService';
+import type { Legislation } from '@/types/legislation';
+
+export interface CompareCandidatePayload {
+  id: string;
+  identifier?: string;
+  title?: string;
+  jurisdictionName?: string;
+  embedding?: number[];
+  geminiSummary?: string | null;
+  longGeminiSummary?: string | null;
+  enactedAt?: string | null;
+  latestActionAt?: string | null;
+  statusText?: string | null;
+  chamber?: string | null;
+  subjects?: string[];
+}
+
+export interface CompareCandidatesResponse {
+  query: string;
+  detectedTopics: { broad: string[]; narrow: string[] };
+  candidates: CompareCandidatePayload[];
+}
+
+const CANDIDATE_LIMIT = 300;
+
+const PROJECTION = {
+  id: 1,
+  identifier: 1,
+  title: 1,
+  jurisdictionName: 1,
+  embedding: 1,
+  geminiSummary: 1,
+  longGeminiSummary: 1,
+  enactedAt: 1,
+  latestActionAt: 1,
+  statusText: 1,
+  chamber: 1,
+  subjects: 1,
+} as const;
+
+function serializeDate(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+function toPayload(doc: Legislation): CompareCandidatePayload {
+  return {
+    id: doc.id,
+    identifier: doc.identifier,
+    title: doc.title,
+    jurisdictionName: doc.jurisdictionName,
+    embedding: doc.embedding,
+    geminiSummary: doc.geminiSummary,
+    longGeminiSummary: doc.longGeminiSummary,
+    enactedAt: serializeDate(doc.enactedAt),
+    latestActionAt: serializeDate(doc.latestActionAt),
+    statusText: doc.statusText,
+    chamber: doc.chamber,
+    subjects: doc.subjects,
+  };
+}
+
+export async function getComparisonCandidates(
+  query: string,
+  options: { enactedOnly?: boolean; showCongress?: boolean } = {},
+): Promise<CompareCandidatesResponse> {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return { query: trimmed, detectedTopics: { broad: [], narrow: [] }, candidates: [] };
+  }
+
+  const classification = classifyLegislationTopics(trimmed);
+  const broadTopics = classification.broadTopics;
+  const narrowTopics = classification.narrowTopics;
+
+  const collection = await getCollection('legislation');
+  const matchConditions: Record<string, unknown>[] = [];
+
+  if (options.enactedOnly) {
+    matchConditions.push({ enactedAt: { $exists: true, $ne: null } });
+  }
+
+  if (!options.showCongress) {
+    matchConditions.push({ jurisdictionName: { $ne: 'United States Congress' } });
+  }
+
+  const topicOr: Record<string, unknown>[] = [];
+  if (broadTopics.length > 0) {
+    topicOr.push({ 'topicClassification.broadTopics': { $in: broadTopics } });
+  }
+  if (narrowTopics.length > 0) {
+    topicOr.push({ 'topicClassification.narrowTopics': { $in: narrowTopics } });
+  }
+
+  const searchOr = [
+    { title: { $regex: trimmed, $options: 'i' } },
+    { summary: { $regex: trimmed, $options: 'i' } },
+    { identifier: { $regex: trimmed, $options: 'i' } },
+    { subjects: { $regex: trimmed, $options: 'i' } },
+    { geminiSummary: { $regex: trimmed, $options: 'i' } },
+    { latestActionDescription: { $regex: trimmed, $options: 'i' } },
+  ];
+
+  for (const term of trimmed.split(/\s+/).filter((t) => t.length > 2)) {
+    searchOr.push(
+      { title: { $regex: term, $options: 'i' } },
+      { geminiSummary: { $regex: term, $options: 'i' } },
+      { subjects: { $regex: term, $options: 'i' } },
+    );
+  }
+
+  const contentOr = [...topicOr, ...searchOr];
+  if (contentOr.length > 0) {
+    matchConditions.push({ $or: contentOr });
+  }
+
+  const filter = matchConditions.length > 0 ? { $and: matchConditions } : {};
+
+  let docs = await collection
+    .find(filter, { projection: PROJECTION })
+    .sort({ latestActionAt: -1, updatedAt: -1 })
+    .limit(CANDIDATE_LIMIT)
+    .toArray();
+
+  if (docs.length < 50) {
+    const fallbackFilter: Record<string, unknown> = {};
+    if (options.enactedOnly) {
+      fallbackFilter.enactedAt = { $exists: true, $ne: null };
+    }
+    if (!options.showCongress) {
+      fallbackFilter.jurisdictionName = { $ne: 'United States Congress' };
+    }
+
+    const fallbackDocs = await collection
+      .find(fallbackFilter, { projection: PROJECTION })
+      .sort({ latestActionAt: -1 })
+      .limit(CANDIDATE_LIMIT)
+      .toArray();
+
+    const seen = new Set(docs.map((d) => d.id));
+    for (const doc of fallbackDocs) {
+      if (!seen.has(doc.id)) {
+        docs.push(doc);
+        seen.add(doc.id);
+      }
+      if (docs.length >= CANDIDATE_LIMIT) break;
+    }
+  }
+
+  const withEmbeddings = docs.filter((d) => d.embedding?.length);
+  const withoutEmbeddings = docs.filter((d) => !d.embedding?.length);
+  const ordered = [...withEmbeddings, ...withoutEmbeddings].slice(0, CANDIDATE_LIMIT);
+
+  return {
+    query: trimmed,
+    detectedTopics: { broad: broadTopics, narrow: narrowTopics },
+    candidates: ordered.map((doc) => toPayload(doc as Legislation)),
+  };
+}

--- a/src/types/legislation.ts
+++ b/src/types/legislation.ts
@@ -65,6 +65,10 @@ export interface Legislation {
   // Performance optimization field
   enactedAt?: Date | null; // Date when the legislation was enacted (null if not enacted)
   enactedFieldUpdatedAt?: Date; // When the enactedAt field was last computed
+  // Browser semantic search embeddings (built offline via build-legislation-embeddings.ts)
+  embedding?: number[];
+  embeddingModel?: string;
+  embeddingTextHash?: string;
 }
 
 // Bookmark/SavedLegislation Types


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a zero-cost cross-state legislation comparison feature on `/summaries`, inspired by [ask-the-declaration](https://github.com/swapniltamse/ask-the-declaration).

Users can search a policy issue (e.g. "minimum wage", "gun control") and see the most relevant bill from each state, with their own state highlighted. All semantic search and optional comparison synthesis runs in the browser — no paid API calls at query time.

## Architecture

- **Server pre-filter** (`GET /api/legislation/compare`): topic classification + keyword search returns ~300 candidate bills with pre-computed embeddings
- **Browser semantic search** (`useSemanticSearch`): `Xenova/all-MiniLM-L6-v2` embeds the query locally and reranks candidates via cosine similarity
- **Per-state grouping**: top 1 bill per jurisdiction, user's state pinned first
- **Optional synthesis** (`useComparisonSynthesis`): `Xenova/LaMini-Flan-T5-77M` generates a grounded comparison paragraph from retrieved bill summaries (opt-in button)

## CI fix

Fixed Vercel build failure caused by:
1. `pdf-parse` entrypoint running a debug harness that reads `./test/data/05-versions-space.pdf` at import time — replaced with lazy import of `pdf-parse/lib/pdf-parse.js`
2. `email.ts` throwing at module load when SMTP env vars are unset — deferred transporter init until `sendEmail()` is called
3. Reverted `next build --webpack` to default Turbopack build

## Setup required

1. Run `npm run build-embeddings` against your MongoDB to populate bill embeddings (semantic search falls back to keyword matching until this runs)
2. Optionally run `npm run build-embeddings -- --limit=1000` for a partial index during development

## Cost

- $0 per query — models download from HuggingFace CDN once (~53 MB total) and cache in the browser
- No Gemini, OpenStates live API, or vector DB usage in the compare flow
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3967-2998-76e5-9a0f-182977fdc426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3967-2998-76e5-9a0f-182977fdc426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

